### PR TITLE
Implement ConsoleRenderer with symbol sets, layering and HUD

### DIFF
--- a/src/infra/io_console/ActorKind.cpp
+++ b/src/infra/io_console/ActorKind.cpp
@@ -1,0 +1,14 @@
+#include "infra/io_console/ActorKind.hpp"
+
+#include "domain/entities/actors/Actor.hpp"
+#include "domain/entities/actors/Player.hpp"
+
+namespace Infrastructure::IOConsole {
+
+bool is_player_actor(const Domain::Entities::Actor &actor) noexcept
+{
+    // TODO: in future consider having flag or enum instead of relying on RTTI
+    return dynamic_cast<const Domain::Entities::Player *>(&actor) != nullptr;
+}
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/ActorKind.hpp
+++ b/src/infra/io_console/ActorKind.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Domain::Entities {
+class Actor;
+class Player; // forward declare; include Player header in .cpp where used
+} // namespace Domain::Entities
+
+namespace Infrastructure::IOConsole {
+
+// Is this actor the player?
+[[nodiscard]] bool is_player_actor(const Domain::Entities::Actor &actor) noexcept;
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/ConsoleFrameBuilder.cpp
+++ b/src/infra/io_console/ConsoleFrameBuilder.cpp
@@ -1,0 +1,138 @@
+#include "infra/io_console/ConsoleFrameBuilder.hpp"
+
+#include "domain/core/GameState.hpp"
+#include "domain/entities/Map.hpp"
+#include "domain/entities/Tile.hpp"
+#include "domain/entities/actors/Actor.hpp"
+#include "domain/entities/items/Item.hpp"
+
+#include "infra/io_console/ActorKind.hpp"
+#include "infra/io_console/ConsoleRenderUtils.hpp" 
+
+#include <cstddef>
+#include <cstdint>
+#include <sstream>
+#include <string>
+
+namespace Infrastructure::IOConsole {
+
+namespace {
+
+using Domain::Core::GameState;
+using Domain::Entities::TileType;
+
+[[nodiscard]] bool in_bounds_xy(const GameState &state, std::int32_t x, std::int32_t y)
+{
+    if (x < 0 || y < 0) {
+        return false;
+    }
+    const auto ux = static_cast<std::size_t>(x);
+    const auto uy = static_cast<std::size_t>(y);
+    return ux < state.map.width() && uy < state.map.height();
+}
+
+[[nodiscard]] std::string tile_to_glyph(const GameState &state, const SymbolSet &sym, std::size_t x,
+                                        std::size_t y)
+{
+    const auto &tile = state.map.grid().at(x, y);
+
+    switch (tile.type) {
+    case TileType::Wall:
+        return sym.wall;
+    case TileType::Floor:
+        return sym.floor;
+    default:
+        return sym.unknown_tile;
+    }
+}
+
+} // namespace
+
+ConsoleFrameBuilder::Frame ConsoleFrameBuilder::build(const GameState &state, const SymbolSet &sym)
+{
+    auto grid = build_grid(state, sym);
+
+    Frame frame;
+    frame.lines = grid.to_lines();
+    frame.hud   = build_hud(state, sym);
+    return frame;
+}
+
+RenderGrid ConsoleFrameBuilder::build_grid(const GameState &state, const SymbolSet &sym)
+{
+    const auto w = static_cast<std::size_t>(state.map.width());
+    const auto h = static_cast<std::size_t>(state.map.height());
+
+    RenderGrid grid{w, h};
+
+    // Base: tiles.
+    for (std::size_t y = 0; y < h; ++y) {
+        for (std::size_t x = 0; x < w; ++x) {
+            grid.at(x, y) = tile_to_glyph(state, sym, x, y);
+        }
+    }
+
+    // Items overlay.
+    for (const auto &it_ptr : state.items) {
+        if (!it_ptr) {
+            continue;
+        }
+        const auto &p = it_ptr->pos;
+        if (!in_bounds_xy(state, p.x, p.y)) {
+            continue;
+        }
+        grid.at(static_cast<std::size_t>(p.x), static_cast<std::size_t>(p.y)) = sym.item;
+    }
+
+    // Actors overlay (actors override items).
+    for (const auto &a_ptr : state.actors) {
+        if (!a_ptr) {
+            continue;
+        }
+
+        const auto &p = a_ptr->pos;
+        if (!in_bounds_xy(state, p.x, p.y)) {
+            continue;
+        }
+
+        std::string g;
+        if (auto custom = glyph_to_utf8(a_ptr->glyph); custom.has_value()) {
+            g = *custom;
+        } else {
+            g = is_player_actor(*a_ptr) ? sym.player : sym.enemy;
+        }
+
+        grid.at(static_cast<std::size_t>(p.x), static_cast<std::size_t>(p.y)) = std::move(g);
+    }
+
+    return grid;
+}
+
+std::string ConsoleFrameBuilder::build_hud(const GameState &state, const SymbolSet &sym)
+{
+    std::ostringstream oss;
+
+    oss << "Turn: " << state.turn << "  "
+        << "Score: " << state.score << "  ";
+
+    if (state.victory) {
+        oss << "[VICTORY] ";
+    }
+    if (state.defeat) {
+        oss << "[DEFEAT] ";
+    }
+
+    // Best-effort player HP from actors[0].
+    if (!state.actors.empty() && state.actors[0]) {
+        const auto &st = state.actors[0]->stats;
+        if constexpr (HasHpAndHpMax<decltype(st)>) {
+            oss << sym.hp_label << ": " << st.hp << "/" << st.max_hp;
+        } else if constexpr (HasHpOnly<decltype(st)>) {
+            oss << sym.hp_label << ": " << st.hp;
+        }
+    }
+
+    return oss.str();
+}
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/ConsoleFrameBuilder.hpp
+++ b/src/infra/io_console/ConsoleFrameBuilder.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "infra/io_console/RenderGrid.hpp"
+#include "infra/io_console/SymbolSet.hpp"
+
+#include <string>
+#include <vector>
+
+namespace Domain::Core {
+struct GameState;
+}
+
+namespace Infrastructure::IOConsole {
+
+// Builds renderable grid and HUD from GameState. No terminal IO.
+class ConsoleFrameBuilder {
+public:
+    struct Frame {
+        std::vector<std::string> lines;
+        std::string hud;
+    };
+
+    [[nodiscard]] static Frame build(const Domain::Core::GameState &state, const SymbolSet &sym);
+
+private:
+    static RenderGrid build_grid(const Domain::Core::GameState &state, const SymbolSet &sym);
+    static std::string build_hud(const Domain::Core::GameState &state, const SymbolSet &sym);
+};
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/ConsoleRenderUtils.hpp
+++ b/src/infra/io_console/ConsoleRenderUtils.hpp
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <cctype>
+#include <optional>
+#include <string>
+#include <type_traits>
+
+namespace Infrastructure::IOConsole {
+
+template <typename T>
+concept HasMemberUtf8 = requires(const T &t) {
+    { t.utf8 } -> std::convertible_to<std::string>;
+};
+
+template <typename T>
+concept HasMemberSymbol = requires(const T &t) {
+    { t.symbol } -> std::convertible_to<std::string>;
+};
+
+template <typename T>
+concept HasMemberCh = requires(const T &t) { t.ch; };
+
+namespace detail {
+
+[[nodiscard]] inline bool is_placeholder_string(const std::string &s) noexcept
+{
+    if (s.empty()) {
+        return true;
+    }
+
+    // Treat a single "?" as placeholder (common default)
+    if (s.size() == 1 && s[0] == '?') {
+        return true;
+    }
+
+    // Treat “all whitespace” as placeholder
+    for (unsigned char c : s) {
+        if (!std::isspace(c) && c != '\0') {
+            return false;
+        }
+    }
+    return true;
+}
+
+[[nodiscard]] inline bool is_valid_char_glyph(char c) noexcept
+{
+    // Reject common “empty/default” values
+    if (c == '\0' || c == '?' || std::isspace(static_cast<unsigned char>(c))) {
+        return false;
+    }
+    
+    // Require visible single-cell ASCII for now
+    // TODO: wider codepoints
+    return std::isgraph(static_cast<unsigned char>(c)) != 0;
+}
+
+} // namespace detail
+
+// A “valid” glyph must be explicitly meaningful
+template <typename GlyphT>
+[[nodiscard]] inline std::optional<std::string> glyph_to_utf8(const GlyphT &g)
+{
+    if constexpr (HasMemberUtf8<GlyphT>) {
+        const std::string s = g.utf8;
+        if (!detail::is_placeholder_string(s)) {
+            return s;
+        }
+    }
+
+    if constexpr (HasMemberSymbol<GlyphT>) {
+        const std::string s = g.symbol;
+        if (!detail::is_placeholder_string(s)) {
+            return s;
+        }
+    }
+
+    if constexpr (HasMemberCh<GlyphT>) {
+        using ChT = std::remove_cvref_t<decltype(g.ch)>;
+        if constexpr (std::is_same_v<ChT, char>) {
+            if (detail::is_valid_char_glyph(g.ch)) {
+                return std::string{g.ch};
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+template <typename StatsT>
+concept HasHpAndHpMax = requires(const StatsT &s) {
+    { s.hp } -> std::convertible_to<int>;
+    { s.hp_max } -> std::convertible_to<int>;
+};
+
+template <typename StatsT>
+concept HasHpOnly = requires(const StatsT &s) {
+    { s.hp } -> std::convertible_to<int>;
+};
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/ConsoleRenderer.cpp
+++ b/src/infra/io_console/ConsoleRenderer.cpp
@@ -1,8 +1,20 @@
 #include "infra/io_console/ConsoleRenderer.hpp"
 
+#include "domain/core/GameState.hpp"
+#include "infra/io_console/ConsoleFrameBuilder.hpp"
+#include "infra/io_console/ConsoleTerminalAnsi.hpp"
+#include "infra/io_console/SymbolSet.hpp"
+
 namespace Infrastructure::IOConsole {
-void ConsoleRenderer::draw(const Domain::Core::GameState &)
+
+void ConsoleRenderer::draw(const Domain::Core::GameState &state)
 {
-    // TODO: draw game state in the console
+    const auto &sym = get_symbol_set(symbols_id_);
+
+    const auto frame = ConsoleFrameBuilder::build(state, sym);
+
+    ConsoleTerminalAnsi terminal;
+    terminal.draw_full(frame.lines, frame.hud);
 }
+
 } // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/ConsoleRenderer.hpp
+++ b/src/infra/io_console/ConsoleRenderer.hpp
@@ -1,9 +1,21 @@
 #pragma once
+
 #include "app/loop/IRenderer.hpp"
+#include "infra/io_console/SymbolSet.hpp"
 
 namespace Infrastructure::IOConsole {
+
 class ConsoleRenderer final : public Application::Loop::IRenderer {
 public:
-    void draw(const Domain::Core::GameState &) override; // stub: no output
+    ConsoleRenderer() = default;
+    explicit ConsoleRenderer(SymbolSetId id) : symbols_id_(id) {}
+
+    void set_symbol_set(SymbolSetId id) noexcept { symbols_id_ = id; }
+
+    void draw(const Domain::Core::GameState &) override;
+
+private:
+    SymbolSetId symbols_id_{SymbolSetId::Ascii};
 };
+
 } // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/ConsoleTerminalAnsi.cpp
+++ b/src/infra/io_console/ConsoleTerminalAnsi.cpp
@@ -1,0 +1,20 @@
+#include "infra/io_console/ConsoleTerminalAnsi.hpp"
+
+#include <iostream>
+
+namespace Infrastructure::IOConsole {
+
+void ConsoleTerminalAnsi::draw_full(const std::vector<std::string> &lines,
+                                    const std::string &hud) const
+{
+    // Clear screen + move cursor to home.
+    std::cout << "\x1b[2J\x1b[H";
+
+    for (const auto &line : lines) {
+        std::cout << line << '\n';
+    }
+    std::cout << hud << '\n';
+    std::cout.flush();
+}
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/ConsoleTerminalAnsi.hpp
+++ b/src/infra/io_console/ConsoleTerminalAnsi.hpp
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace Infrastructure::IOConsole {
+
+// Minimal ANSI backend: full redraw.
+class ConsoleTerminalAnsi {
+public:
+    void draw_full(const std::vector<std::string> &lines, const std::string &hud) const;
+};
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/RenderGrid.cpp
+++ b/src/infra/io_console/RenderGrid.cpp
@@ -1,0 +1,51 @@
+#include "infra/io_console/RenderGrid.hpp"
+
+#include <stdexcept>
+
+namespace Infrastructure::IOConsole {
+
+RenderGrid::RenderGrid(std::size_t w, std::size_t h) { resize(w, h); }
+
+void RenderGrid::resize(std::size_t w, std::size_t h)
+{
+    w_ = w;
+    h_ = h;
+    cells_.assign(w_ * h_, " ");
+}
+
+bool RenderGrid::in_bounds(std::size_t x, std::size_t y) const noexcept { return x < w_ && y < h_; }
+
+const std::string &RenderGrid::at(std::size_t x, std::size_t y) const
+{
+    if (!in_bounds(x, y)) {
+        throw std::out_of_range("RenderGrid::at out of bounds");
+    }
+    return cells_[index(x, y)];
+}
+
+std::string &RenderGrid::at(std::size_t x, std::size_t y)
+{
+    if (!in_bounds(x, y)) {
+        throw std::out_of_range("RenderGrid::at out of bounds");
+    }
+    return cells_[index(x, y)];
+}
+
+std::vector<std::string> RenderGrid::to_lines() const
+{
+    std::vector<std::string> lines;
+    lines.reserve(h_);
+
+    for (std::size_t y = 0; y < h_; ++y) {
+        std::string row;
+        row.reserve(w_);
+        for (std::size_t x = 0; x < w_; ++x) {
+            row += cells_[index(x, y)];
+        }
+        lines.push_back(std::move(row));
+    }
+
+    return lines;
+}
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/RenderGrid.hpp
+++ b/src/infra/io_console/RenderGrid.hpp
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace Infrastructure::IOConsole {
+
+// A safe grid for UTF-8 glyph strings: each cell stores one glyph string
+class RenderGrid {
+public:
+    RenderGrid() = default;
+    RenderGrid(std::size_t w, std::size_t h);
+
+    void resize(std::size_t w, std::size_t h);
+
+    [[nodiscard]] std::size_t width() const noexcept { return w_; }
+    [[nodiscard]] std::size_t height() const noexcept { return h_; }
+
+    [[nodiscard]] bool in_bounds(std::size_t x, std::size_t y) const noexcept;
+
+    // Cell access
+    [[nodiscard]] const std::string &at(std::size_t x, std::size_t y) const;
+    std::string &at(std::size_t x, std::size_t y);
+
+    // Convert to printable lines (each line is concatenation of glyphs).
+    [[nodiscard]] std::vector<std::string> to_lines() const;
+
+private:
+    std::size_t w_{0};
+    std::size_t h_{0};
+    std::vector<std::string> cells_{};
+
+    [[nodiscard]] std::size_t index(std::size_t x, std::size_t y) const noexcept
+    {
+        return y * w_ + x;
+    }
+};
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/SymbolSet.cpp
+++ b/src/infra/io_console/SymbolSet.cpp
@@ -1,0 +1,37 @@
+#include "infra/io_console/SymbolSet.hpp"
+
+namespace Infrastructure::IOConsole {
+
+const SymbolSet &get_symbol_set(SymbolSetId id) noexcept
+{
+    static const SymbolSet ascii{
+        .wall         = "#",
+        .floor        = " ",
+        .unknown_tile = "?",
+        .player       = "@",
+        .enemy        = "E",
+        .item         = "*",
+        .hp_label     = "HP",
+    };
+
+    // More pretty. Let's keep it as an option
+    static const SymbolSet unicode_simple{
+        .wall         = "█",
+        .floor        = "⠀",
+        .unknown_tile = "?",
+        .player       = "☻",
+        .enemy        = "☠",
+        .item         = "♦",
+        .hp_label     = "♥",
+    };
+
+    switch (id) {
+    case SymbolSetId::UnicodeSimple:
+        return unicode_simple;
+    case SymbolSetId::Ascii:
+    default:
+        return ascii;
+    }
+}
+
+} // namespace Infrastructure::IOConsole

--- a/src/infra/io_console/SymbolSet.hpp
+++ b/src/infra/io_console/SymbolSet.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <string>
+
+namespace Infrastructure::IOConsole {
+
+enum class SymbolSetId {
+    Ascii,
+    UnicodeSimple,
+};
+
+struct SymbolSet {
+    // Map tiles
+    std::string wall;
+    std::string floor;
+    std::string unknown_tile;
+
+    // Entities
+    std::string player;
+    std::string enemy;
+    std::string item;
+
+    // HUD
+    std::string hp_label;
+};
+
+[[nodiscard]] const SymbolSet &get_symbol_set(SymbolSetId id) noexcept;
+
+} // namespace Infrastructure::IOConsole

--- a/tests/infra/test_infra_console_renderer.cpp
+++ b/tests/infra/test_infra_console_renderer.cpp
@@ -1,14 +1,115 @@
-#include "domain/core/GameState.hpp"
-#include "infra/io_console/ConsoleRenderer.hpp"
 #include <cstdlib>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include "domain/core/GameState.hpp"
+#include "domain/core/Position.hpp"
+#include "domain/entities/Map.hpp"
+#include "domain/entities/Tile.hpp"
+#include "domain/entities/actors/Actor.hpp"
+#include "domain/entities/items/Item.hpp"
+
+#include "infra/io_console/ConsoleRenderer.hpp"
+#include "test_utils.hpp"
+
+#include "domain/entities/actors/Player.hpp" 
+
+namespace {
+using Domain::Core::GameState;
+using Domain::Core::Position;
+using Domain::Entities::Actor;
+using Domain::Entities::Item;
+using Domain::Entities::Map;
+using Domain::Entities::TileType;
+
+using Infrastructure::IOConsole::ConsoleRenderer;
+using Infrastructure::IOConsole::SymbolSetId;
+
+using TestUtils::expect;
+using TestUtils::fail_count;
+
+struct TestEnemy final : public Actor {
+    void action(GameState &) override {}
+};
+
+struct TestItem final : public Item {};
+
+void fill_floor(Map &map)
+{
+    for (std::size_t y = 0; y < map.height(); ++y) {
+        for (std::size_t x = 0; x < map.width(); ++x) {
+            auto &t           = map.grid().at(x, y);
+            t.type            = TileType::Floor;
+            t.blocks_movement = false;
+            t.blocks_sight    = false;
+        }
+    }
+}
+
+} // namespace
 
 int main()
 {
-    Infrastructure::IOConsole::ConsoleRenderer r{};
-    Domain::Core::GameState state{};
-    r.draw(state); // should be a no-op
+    GameState state{};
+    state.map = Map{10, 5};
+    fill_floor(state.map);
 
-    // TODO: proper check
+    // Place one wall
+    {
+        auto &t           = state.map.grid().at(0, 0);
+        t.type            = TileType::Wall;
+        t.blocks_movement = true;
+        t.blocks_sight    = true;
+    }
 
-    return EXIT_SUCCESS;
+    // Player at (1,1)
+    {
+        auto p = std::make_unique<Domain::Entities::Player>();
+        p->pos = Position{1, 1};
+        state.actors.push_back(std::move(p));
+    }
+
+    // Enemy at (2,1)
+    {
+        auto e = std::make_unique<TestEnemy>();
+        e->pos = Position{2, 1};
+        state.actors.push_back(std::move(e));
+    }
+
+    // Item at (3,1)
+    {
+        auto it = std::make_unique<TestItem>();
+        it->pos = Position{3, 1};
+        state.items.push_back(std::move(it));
+    }
+
+    state.turn  = 42;
+    state.score = 7;
+
+    ConsoleRenderer renderer{SymbolSetId::Ascii};
+
+    // Capture output
+    std::ostringstream capture;
+    auto *old = std::cout.rdbuf(capture.rdbuf());
+
+    renderer.draw(state);
+
+    std::cout.rdbuf(old);
+
+    const std::string out = capture.str();
+
+    expect(!out.empty(), "ConsoleRenderer produces output");
+    expect(out.find("Turn: 42") != std::string::npos, "HUD contains turn");
+    expect(out.find("Score: 7") != std::string::npos, "HUD contains score");
+
+    // ASCII symbols should appear
+    expect(out.find("#") != std::string::npos, "Wall (#) present");
+    expect(out.find(" ") != std::string::npos, "Floor (.) present");
+    expect(out.find("@") != std::string::npos, "Player (@) present");
+    expect(out.find("E") != std::string::npos, "Enemy (E) present");
+    expect(out.find("*") != std::string::npos, "Item (*) present");
+
+    return fail_count == 0 ? EXIT_SUCCESS : EXIT_FAILURE;
 }


### PR DESCRIPTION
## Description
- Add SymbolSet (ASCII + UnicodeSimple) and selection API
- Introduce RenderGrid per-cell buffer to support UTF-8 glyphs safely
- Add ConsoleFrameBuilder to render tiles/items/actors with correct layering
- Add minimal ANSI terminal backend for full-screen redraw
- Implement ConsoleRenderer to compose frame and print it
- Add unit test covering output, HUD fields, and basic symbols

## Task ID in project
Closes #25

## Checklist
- [x] I went to the project and linked this PR to the task.
- [x] I set assignee and reporter on the task.
- [x] I went to the team chat and asked for review.
