### PR TITLE
Feature 20 - Pickup System

### DIFF
--- a/src/app/loop/GameLoop.cpp
+++ b/src/app/loop/GameLoop.cpp
@@ -4,6 +4,7 @@
 
 #include "app/systems/CombatSystem.hpp"
 #include "app/systems/EnemyAISystem.hpp"
+#include "app/systems/PickupSystem.hpp"
 #include "app/systems/PlayerSystem.hpp"
 
 #include "domain/core/GameState.hpp"
@@ -21,6 +22,7 @@ int GameLoop::run(Domain::Core::GameState &state)
     Application::Systems::PlayerSystem player_system{};
     Application::Systems::EnemyAISystem enemy_ai_system{};
     Application::Systems::CombatSystem combat_system{};
+    Application::Systems::PickupSystem pickup_system{};
 
     bool running = true;
 
@@ -40,6 +42,7 @@ int GameLoop::run(Domain::Core::GameState &state)
             break;
         }
 
+        pickup_system.process(state);
         enemy_ai_system.action(state);
         combat_system.resolve(state);
 

--- a/src/app/systems/PickupSystem.cpp
+++ b/src/app/systems/PickupSystem.cpp
@@ -3,8 +3,10 @@
 
 #include "domain/core/GameState.hpp"
 #include "domain/entities/actors/Player.hpp"
+#include "domain/entities/items/Coin.hpp"
 #include "domain/entities/items/HealthPotion.hpp"
 #include "domain/entities/items/Key.hpp"
+#include "domain/entities/items/Sword.hpp"
 
 namespace {
 using Domain::Core::GameState;
@@ -42,6 +44,12 @@ void PickupSystem::process(Domain::Core::GameState &state)
                 player->stats.hp +
                     dynamic_cast<Domain::Entities::HealthPotion *>(it->get())->healingValue,
                 player->stats.max_hp);
+            it = state.items.erase(it);
+        } else if (dynamic_cast<Domain::Entities::Sword *>(it->get())) {
+            player->stats.atk += dynamic_cast<Domain::Entities::Sword *>(it->get())->attack_bonus;
+            it = state.items.erase(it);
+        } else if (dynamic_cast<Domain::Entities::Coin *>(it->get())) {
+            state.score += dynamic_cast<Domain::Entities::Coin *>(it->get())->value;
             it = state.items.erase(it);
         } else {
             ++it;

--- a/src/app/systems/PickupSystem.cpp
+++ b/src/app/systems/PickupSystem.cpp
@@ -38,7 +38,8 @@ void PickupSystem::process(Domain::Core::GameState &state)
 
         if (dynamic_cast<Domain::Entities::Key *>(it->get())) {
             player->has_key = true;
-            it              = state.items.erase(it);
+            state.score += 100;
+            it = state.items.erase(it);
         } else if (dynamic_cast<Domain::Entities::HealthPotion *>(it->get())) {
             player->stats.hp = std::min(
                 player->stats.hp +

--- a/src/app/systems/PickupSystem.cpp
+++ b/src/app/systems/PickupSystem.cpp
@@ -1,9 +1,51 @@
 #include "app/systems/PickupSystem.hpp"
+#include <algorithm>
+
 #include "domain/core/GameState.hpp"
+#include "domain/entities/actors/Player.hpp"
+#include "domain/entities/items/HealthPotion.hpp"
+#include "domain/entities/items/Key.hpp"
+
+namespace {
+using Domain::Core::GameState;
+using Domain::Entities::Player;
+
+Player *find_player(GameState &state)
+{
+    for (auto &actor : state.actors) {
+        if (auto player = dynamic_cast<Player *>(actor.get()))
+            return player;
+    }
+    return nullptr;
+}
+} // namespace
 
 namespace Application::Systems {
-void PickupSystem::process(Domain::Core::GameState &)
+
+void PickupSystem::process(Domain::Core::GameState &state)
 {
-    // TODO: find a girlfriend
+    Player *player = find_player(state);
+    if (player == nullptr)
+        return;
+
+    for (auto it = state.items.begin(); it != state.items.end();) {
+        if ((*it)->pos != player->pos) {
+            ++it;
+            continue;
+        }
+
+        if (dynamic_cast<Domain::Entities::Key *>(it->get())) {
+            player->has_key = true;
+            it              = state.items.erase(it);
+        } else if (dynamic_cast<Domain::Entities::HealthPotion *>(it->get())) {
+            player->stats.hp = std::min(
+                player->stats.hp +
+                    dynamic_cast<Domain::Entities::HealthPotion *>(it->get())->healingValue,
+                player->stats.max_hp);
+            it = state.items.erase(it);
+        } else {
+            ++it;
+        }
+    }
 }
 } // namespace Application::Systems

--- a/src/app/systems/PlayerSystem.cpp
+++ b/src/app/systems/PlayerSystem.cpp
@@ -2,10 +2,6 @@
 #include "app/loop/InputCommand.hpp"
 #include "domain/core/AttackIntent.hpp"
 #include "domain/core/GameState.hpp"
-#include "domain/entities/items/HealthPotion.hpp"
-#include "domain/entities/items/Item.hpp"
-#include "domain/entities/items/Key.hpp"
-#include <algorithm>
 #include <type_traits>
 #include <variant>
 
@@ -60,8 +56,6 @@ bool PlayerSystem::try_move_player(Domain::Core::GameState &state, Domain::Entit
     }
 
     player.pos = target;
-    pick_items_on_player_tile(state, player);
-
     return true;
 }
 
@@ -114,27 +108,4 @@ Domain::Core::Position PlayerSystem::moved_position(Domain::Core::Position from,
     return Domain::Core::Position{static_cast<std::uint8_t>(x), static_cast<std::uint8_t>(y)};
 }
 
-void PlayerSystem::pick_items_on_player_tile(Domain::Core::GameState &state,
-                                             Domain::Entities::Player &player)
-{
-    for (std::size_t i = 0; i < state.items.size();) {
-        auto &item = state.items[i];
-        if (item->pos.x != player.pos.x || item->pos.y != player.pos.y) {
-            ++i;
-            continue;
-        }
-
-        if (dynamic_cast<Domain::Entities::Key *>(item.get()) != nullptr) {
-            player.has_key = true;
-            state.score += 100;
-        } else if (auto *potion = dynamic_cast<Domain::Entities::HealthPotion *>(item.get())) {
-            player.stats.hp =
-                std::min(player.stats.max_hp, player.stats.hp + std::max(1, potion->healingValue));
-        }
-
-        const auto idx =
-            static_cast<std::vector<std::unique_ptr<Domain::Entities::Item>>::difference_type>(i);
-        state.items.erase(state.items.begin() + idx);
-    }
-}
 } // namespace Application::Systems

--- a/src/domain/entities/items/Coin.hpp
+++ b/src/domain/entities/items/Coin.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include "domain/entities/items/Item.hpp"
+
+namespace Domain::Entities {
+class Coin final : public Item {
+public:
+    int value{};
+};
+} // namespace Domain::Entities

--- a/src/domain/entities/items/Item.hpp
+++ b/src/domain/entities/items/Item.hpp
@@ -10,6 +10,7 @@ public:
     // Data per diagram
     Domain::Core::EntityId id{};
     Domain::Core::Position pos{};
+    Domain::Core::Glyph glyph{};
 
     // Kind-specific data goes in derived types.
 };

--- a/src/domain/entities/items/Sword.hpp
+++ b/src/domain/entities/items/Sword.hpp
@@ -1,0 +1,9 @@
+#pragma once
+#include "domain/entities/items/Item.hpp"
+
+namespace Domain::Entities {
+class Sword final : public Item {
+public:
+    int attack_bonus{};
+};
+} // namespace Domain::Entities

--- a/src/domain/services/SpawnPolicy.cpp
+++ b/src/domain/services/SpawnPolicy.cpp
@@ -192,7 +192,7 @@ void SpawnPolicy::place_items(const Domain::Rules::GameRules &rules, Domain::Cor
         auto coin      = std::make_unique<Domain::Entities::Coin>();
         coin->id.value = static_cast<std::uint32_t>(1300 + i);
         coin->pos      = coin_position.value();
-        coin->value    = 1;
+        coin->value    = 10;
         coin->glyph.ch = '$';
 
         items.push_back(std::move(coin));

--- a/src/domain/services/SpawnPolicy.cpp
+++ b/src/domain/services/SpawnPolicy.cpp
@@ -4,9 +4,11 @@
 #include "domain/entities/Map.hpp"
 #include "domain/entities/actors/Enemy.hpp"
 #include "domain/entities/actors/Player.hpp"
+#include "domain/entities/items/Coin.hpp"
 #include "domain/entities/items/HealthPotion.hpp"
 #include "domain/entities/items/Item.hpp"
 #include "domain/entities/items/Key.hpp"
+#include "domain/entities/items/Sword.hpp"
 #include "domain/rules/GameRules.hpp"
 
 #include "infra/log/Logger.hpp"
@@ -18,63 +20,56 @@
 #include <optional>
 #include <vector>
 
-namespace Domain::Services
+namespace Domain::Services {
+namespace {
+using Domain::Core::Position;
+using Domain::Entities::Map;
+
+bool same_position(Position a, Position b) noexcept { return a.x == b.x && a.y == b.y; }
+
+bool contains_position(const std::vector<Position> &positions, Position candidate) noexcept
 {
-namespace
+    return std::any_of(positions.begin(), positions.end(),
+                       [candidate](Position p) { return same_position(p, candidate); });
+}
+
+std::vector<Position> collect_floor_positions(const Map &map)
 {
-    using Domain::Core::Position;
-    using Domain::Entities::Map;
+    std::vector<Position> floor_positions;
+    floor_positions.reserve(static_cast<std::size_t>(map.width()) * map.height());
 
-    bool same_position(Position a, Position b) noexcept
-    {
-        return a.x == b.x && a.y == b.y;
-    }
-
-    bool contains_position(const std::vector<Position> &positions, Position candidate) noexcept
-    {
-        return std::any_of(positions.begin(), positions.end(),
-                           [candidate](Position p) { return same_position(p, candidate); });
-    }
-
-    std::vector<Position> collect_floor_positions(const Map &map)
-    {
-        std::vector<Position> floor_positions;
-        floor_positions.reserve(static_cast<std::size_t>(map.width()) * map.height());
-
-        for (std::uint16_t y = 0; y < map.height(); ++y) {
-            for (std::uint16_t x = 0; x < map.width(); ++x) {
-                const Position pos{static_cast<std::uint8_t>(x), static_cast<std::uint8_t>(y)};
-                if (map.is_passable(pos)) {
-                    floor_positions.push_back(pos);
-                }
+    for (std::uint16_t y = 0; y < map.height(); ++y) {
+        for (std::uint16_t x = 0; x < map.width(); ++x) {
+            const Position pos{static_cast<std::uint8_t>(x), static_cast<std::uint8_t>(y)};
+            if (map.is_passable(pos)) {
+                floor_positions.push_back(pos);
             }
         }
-        return floor_positions;
     }
+    return floor_positions;
+}
 
-    std::optional<Position> pick_unique_floor(const std::vector<Position> &floor_positions,
-                                              Domain::Core::IRng &rng,
-                                              std::vector<Position> &occupied)
-    {
-        if (floor_positions.empty()) {
-            return std::nullopt;
-        }
-
-        const int last_index = static_cast<int>(floor_positions.size() - 1);
-        const int start      = rng.next_int(0, last_index);
-
-        for (std::size_t offset = 0; offset < floor_positions.size(); ++offset) {
-            const std::size_t idx =
-                (static_cast<std::size_t>(start) + offset) % floor_positions.size();
-            const Position candidate = floor_positions[idx];
-            if (!contains_position(occupied, candidate)) {
-                occupied.push_back(candidate);
-                return candidate;
-            }
-        }
-
+std::optional<Position> pick_unique_floor(const std::vector<Position> &floor_positions,
+                                          Domain::Core::IRng &rng, std::vector<Position> &occupied)
+{
+    if (floor_positions.empty()) {
         return std::nullopt;
     }
+
+    const int last_index = static_cast<int>(floor_positions.size() - 1);
+    const int start      = rng.next_int(0, last_index);
+
+    for (std::size_t offset = 0; offset < floor_positions.size(); ++offset) {
+        const std::size_t idx = (static_cast<std::size_t>(start) + offset) % floor_positions.size();
+        const Position candidate = floor_positions[idx];
+        if (!contains_position(occupied, candidate)) {
+            occupied.push_back(candidate);
+            return candidate;
+        }
+    }
+
+    return std::nullopt;
+}
 } // namespace
 
 void SpawnPolicy::place_player(const Domain::Rules::GameRules &, Domain::Core::IRng &rng,
@@ -92,13 +87,13 @@ void SpawnPolicy::place_player(const Domain::Rules::GameRules &, Domain::Core::I
         player.pos = position.value();
     }
 
-    player.id.value   = 1;
-    player.glyph.ch   = '@';
-    player.stats.hp   = 20;
+    player.id.value     = 1;
+    player.glyph.ch     = '@';
+    player.stats.hp     = 20;
     player.stats.max_hp = 20;
-    player.stats.atk  = 5;
-    player.stats.def  = 1;
-    player.has_key    = false;
+    player.stats.atk    = 5;
+    player.stats.def    = 1;
+    player.has_key      = false;
 
     LOG(INFO) << "SpawnPolicy::place_player done at (" << static_cast<int>(player.pos.x) << ","
               << static_cast<int>(player.pos.y) << ")";
@@ -151,9 +146,10 @@ void SpawnPolicy::place_items(const Domain::Rules::GameRules &rules, Domain::Cor
         return;
     }
 
-    auto key    = std::make_unique<Domain::Entities::Key>();
+    auto key      = std::make_unique<Domain::Entities::Key>();
     key->id.value = 1000;
-    key->pos    = key_position.value();
+    key->pos      = key_position.value();
+    key->glyph.ch = 'K';
     items.push_back(std::move(key));
 
     const std::uint16_t potion_count =
@@ -165,11 +161,41 @@ void SpawnPolicy::place_items(const Domain::Rules::GameRules &rules, Domain::Cor
             break;
         }
 
-        auto potion = std::make_unique<Domain::Entities::HealthPotion>();
+        auto potion          = std::make_unique<Domain::Entities::HealthPotion>();
         potion->id.value     = static_cast<std::uint32_t>(1100 + i);
         potion->pos          = potion_position.value();
+        potion->glyph.ch     = '+';
         potion->healingValue = std::max(1, rules.potion_heal_max);
         items.push_back(std::move(potion));
+    }
+
+    const auto sword_position = pick_unique_floor(floor_positions, rng, occupied);
+    if (sword_position.has_value()) {
+        auto sword          = std::make_unique<Domain::Entities::Sword>();
+        sword->id.value     = 1200;
+        sword->pos          = sword_position.value();
+        sword->glyph.ch     = 'S';
+        sword->attack_bonus = 5;
+
+        items.push_back(std::move(sword));
+    } else {
+        LOG(ERROR) << "SpawnPolicy::place_items failed: no floor tile for sword";
+    }
+
+    for (std::uint16_t i = 0; i < 2; i++) {
+        const auto coin_position = pick_unique_floor(floor_positions, rng, occupied);
+        if (!coin_position.has_value()) {
+            LOG(ERROR) << "SpawnPolicy::place_items stopped: no free floor tile for coin " << i;
+            break;
+        }
+
+        auto coin      = std::make_unique<Domain::Entities::Coin>();
+        coin->id.value = static_cast<std::uint32_t>(1300 + i);
+        coin->pos      = coin_position.value();
+        coin->value    = 1;
+        coin->glyph.ch = '$';
+
+        items.push_back(std::move(coin));
     }
 
     LOG(INFO) << "SpawnPolicy::place_items done, placed=" << items.size();

--- a/src/infra/io_console/ConsoleRenderer.cpp
+++ b/src/infra/io_console/ConsoleRenderer.cpp
@@ -4,8 +4,10 @@
 #include "domain/entities/TileType.hpp"
 #include "domain/entities/actors/Enemy.hpp"
 #include "domain/entities/actors/Player.hpp"
+#include "domain/entities/items/Coin.hpp"
 #include "domain/entities/items/HealthPotion.hpp"
 #include "domain/entities/items/Key.hpp"
+#include "domain/entities/items/Sword.hpp"
 #include "infra/log/Logger.hpp"
 
 #include <cstdint>
@@ -19,71 +21,79 @@
 #include <io.h>
 #endif
 
-namespace Infrastructure::IOConsole
+namespace Infrastructure::IOConsole {
+namespace {
+constexpr std::uint8_t kCellWidth = 2;
+
+constexpr const char *kAnsiReset  = "\x1b[0m";
+constexpr const char *kAnsiWall   = "\x1b[38;5;240m";
+constexpr const char *kAnsiFloor  = "\x1b[38;5;236m";
+constexpr const char *kAnsiPlayer = "\x1b[1;32m";
+constexpr const char *kAnsiEnemy  = "\x1b[1;31m";
+constexpr const char *kAnsiItem   = "\x1b[1;33m";
+
+struct RendererSymbolSet {
+    const char *wall{};
+    const char *floor{};
+    const char *player{};
+    const char *enemy{};
+    const char *key{};
+    const char *potion{};
+    const char *sword{};
+    const char *coin{};
+    const char *fallback{};
+    const char *legend{};
+    const char *name{};
+};
+
+const RendererSymbolSet &get_renderer_symbol_set(SymbolSetId id)
 {
-namespace
+    static const RendererSymbolSet kUnicode{
+        "██",     "░░",
+        "☻ ",     "☠ ",
+        "♦ ",     "✚ ",
+        "⚔ ",     "🪙 ",
+        "· ",     "Legend: ☻ player, ☠ enemy, ♦ key, ✚ potion, ⚔ sword, 🪙 coin, ██ wall, ░░ floor",
+        "unicode"};
+
+    static const RendererSymbolSet kAscii{
+        "##",   "..",
+        "@ ",   "E ",
+        "K ",   "+ ",
+        "S ",   "$ ",
+        "? ",   "Legend: @ player, E enemy, K key, + potion, S sword, $ coin, ## wall, .. floor",
+        "ascii"};
+
+    return (id == SymbolSetId::UnicodeSimple) ? kUnicode : kAscii;
+}
+
+bool stdout_is_tty()
 {
-    constexpr std::uint8_t kCellWidth = 2;
-
-    constexpr const char *kAnsiReset  = "\x1b[0m";
-    constexpr const char *kAnsiWall   = "\x1b[38;5;240m";
-    constexpr const char *kAnsiFloor  = "\x1b[38;5;236m";
-    constexpr const char *kAnsiPlayer = "\x1b[1;32m";
-    constexpr const char *kAnsiEnemy  = "\x1b[1;31m";
-    constexpr const char *kAnsiItem   = "\x1b[1;33m";
-
-    struct RendererSymbolSet
-    {
-        const char *wall{};
-        const char *floor{};
-        const char *player{};
-        const char *enemy{};
-        const char *key{};
-        const char *potion{};
-        const char *fallback{};
-        const char *legend{};
-        const char *name{};
-    };
-
-    const RendererSymbolSet &get_renderer_symbol_set(SymbolSetId id)
-    {
-        static const RendererSymbolSet kUnicode{
-            "██", "░░", "☻ ", "☠ ", "♦ ", "✚ ", "· ",
-            "Legend: ☻ player, ☠ enemy, ♦ key, ✚ potion, ██ wall, ░░ floor", "unicode"};
-        static const RendererSymbolSet kAscii{
-            "##", "..", "@ ", "E ", "K ", "+ ", "? ",
-            "Legend: @ player, E enemy, K key, + potion, ## wall, .. floor", "ascii"};
-
-        return (id == SymbolSetId::UnicodeSimple) ? kUnicode : kAscii;
-    }
-
-    bool stdout_is_tty()
-    {
 #if defined(__linux__) || defined(__APPLE__)
-        return ::isatty(STDOUT_FILENO) != 0;
+    return ::isatty(STDOUT_FILENO) != 0;
 #elif defined(_WIN32)
-        return ::_isatty(_fileno(stdout)) != 0;
+    return ::_isatty(_fileno(stdout)) != 0;
 #else
-        return false;
+    return false;
 #endif
-    }
+}
 
-    std::string colorize(const char *code, const std::string &value, bool enabled)
-    {
-        if (!enabled) {
-            return value;
-        }
-        return std::string(code) + value + kAnsiReset;
+std::string colorize(const char *code, const std::string &value, bool enabled)
+{
+    if (!enabled) {
+        return value;
     }
+    return std::string(code) + value + kAnsiReset;
+}
 
-    std::string tile_cell(const Domain::Entities::TileType type, const RendererSymbolSet &symbols,
-                          bool color_enabled)
-    {
-        if (type == Domain::Entities::TileType::Wall) {
-            return colorize(kAnsiWall, symbols.wall, color_enabled);
-        }
-        return colorize(kAnsiFloor, symbols.floor, color_enabled);
+std::string tile_cell(const Domain::Entities::TileType type, const RendererSymbolSet &symbols,
+                      bool color_enabled)
+{
+    if (type == Domain::Entities::TileType::Wall) {
+        return colorize(kAnsiWall, symbols.wall, color_enabled);
     }
+    return colorize(kAnsiFloor, symbols.floor, color_enabled);
+}
 } // namespace
 
 void ConsoleRenderer::draw(const Domain::Core::GameState &state)
@@ -120,6 +130,10 @@ void ConsoleRenderer::draw(const Domain::Core::GameState &state)
             glyph = symbols.key;
         } else if (dynamic_cast<const Domain::Entities::HealthPotion *>(item.get()) != nullptr) {
             glyph = symbols.potion;
+        } else if (dynamic_cast<const Domain::Entities::Sword *>(item.get()) != nullptr) {
+            glyph = symbols.sword;
+        } else if (dynamic_cast<const Domain::Entities::Coin *>(item.get()) != nullptr) {
+            glyph = symbols.coin;
         }
         cells[item->pos.y][item->pos.x] = colorize(kAnsiItem, glyph, color_enabled);
     }
@@ -130,7 +144,8 @@ void ConsoleRenderer::draw(const Domain::Core::GameState &state)
         }
 
         if (dynamic_cast<const Domain::Entities::Player *>(actor.get()) != nullptr) {
-            cells[actor->pos.y][actor->pos.x] = colorize(kAnsiPlayer, symbols.player, color_enabled);
+            cells[actor->pos.y][actor->pos.x] =
+                colorize(kAnsiPlayer, symbols.player, color_enabled);
         } else if (dynamic_cast<const Domain::Entities::Enemy *>(actor.get()) != nullptr) {
             cells[actor->pos.y][actor->pos.x] = colorize(kAnsiEnemy, symbols.enemy, color_enabled);
         } else {
@@ -154,8 +169,7 @@ void ConsoleRenderer::draw(const Domain::Core::GameState &state)
     }
     std::cout << "+" << border_line << "+\n";
     std::cout << "Turn: " << state.turn << " | Map: " << width << "x" << height
-              << " | Actors: " << state.actors.size() << " | Items: " << state.items.size()
-              << "\n";
+              << " | Actors: " << state.actors.size() << " | Items: " << state.items.size() << "\n";
     std::cout << symbols.legend << "\n";
     std::cout << "Controls: w/a/s/d or arrows move, . wait, q quit\n";
 

--- a/src/infra/io_console/ConsoleRenderer.cpp
+++ b/src/infra/io_console/ConsoleRenderer.cpp
@@ -168,8 +168,23 @@ void ConsoleRenderer::draw(const Domain::Core::GameState &state)
         std::cout << "|\n";
     }
     std::cout << "+" << border_line << "+\n";
-    std::cout << "Turn: " << state.turn << " | Map: " << width << "x" << height
-              << " | Actors: " << state.actors.size() << " | Items: " << state.items.size() << "\n";
+
+    const Domain::Entities::Player *player = nullptr;
+    for (const auto &actor : state.actors) {
+        if (auto p = dynamic_cast<const Domain::Entities::Player *>(actor.get())) {
+            player = p;
+            break;
+        }
+    }
+
+    if (player != nullptr) {
+        std::cout << "Turn: " << state.turn << " | HP: " << player->stats.hp << "/"
+                  << player->stats.max_hp << " | ATK: " << player->stats.atk
+                  << " | Score: " << state.score << "\n";
+    }
+
+    std::cout << " | Map: " << width << "x" << height << " | Actors: " << state.actors.size()
+              << " | Items: " << state.items.size() << "\n";
     std::cout << symbols.legend << "\n";
     std::cout << "Controls: w/a/s/d or arrows move, . wait, q quit\n";
 

--- a/tests/app/test_app_pickupsystem.cpp
+++ b/tests/app/test_app_pickupsystem.cpp
@@ -1,0 +1,179 @@
+#include "app/systems/PickupSystem.hpp"
+
+#include "domain/core/GameState.hpp"
+#include "domain/entities/actors/Player.hpp"
+#include "domain/entities/items/HealthPotion.hpp"
+#include "domain/entities/items/Key.hpp"
+
+#include <cassert>
+#include <memory>
+
+using namespace Domain::Entities;
+using namespace Domain::Core;
+using namespace Application::Systems;
+
+struct TestState {
+    GameState state;
+    Player *player;
+};
+
+static TestState make_state()
+{
+    TestState t;
+
+    auto player = std::make_unique<Player>();
+    player->pos = {1, 1};
+
+    t.player = player.get();
+    t.state.actors.push_back(std::move(player));
+
+    return t;
+}
+
+class UnknownItem final : public Item {};
+
+void test_ignore_unknown_item()
+{
+
+    auto t = make_state();
+
+    t.player->stats.hp = 5;
+
+    auto unknown_item = std::make_unique<UnknownItem>();
+    unknown_item->pos = {1, 1};
+    t.state.items.push_back(std::move(unknown_item));
+
+    PickupSystem system;
+    system.process(t.state);
+
+    assert(!t.player->has_key);
+    assert(t.player->stats.hp == 5);
+    assert(t.state.items.size() == 1);
+}
+
+void test_pickup_key()
+{
+    auto t = make_state();
+
+    auto key = std::make_unique<Key>();
+    key->pos = {1, 1};
+
+    t.state.items.push_back(std::move(key));
+
+    PickupSystem system;
+    system.process(t.state);
+
+    assert(t.player->has_key);
+    assert(t.state.items.empty());
+}
+
+void test_pickup_health_potion()
+{
+    auto t = make_state();
+
+    t.player->stats.hp     = 5;
+    t.player->stats.max_hp = 10;
+
+    auto potion          = std::make_unique<HealthPotion>();
+    potion->pos          = {1, 1};
+    potion->healingValue = 5;
+    t.state.items.push_back(std::move(potion));
+
+    PickupSystem system;
+    system.process(t.state);
+
+    assert(t.player->stats.hp > 5);
+    assert(t.player->stats.hp <= t.player->stats.max_hp);
+    assert(t.state.items.empty());
+}
+
+void test_pickup_doesnt_exceed_max_hp()
+{
+    auto t = make_state();
+
+    t.player->stats.hp     = 9;
+    t.player->stats.max_hp = 10;
+
+    auto potion          = std::make_unique<HealthPotion>();
+    potion->pos          = {1, 1};
+    potion->healingValue = 5;
+    t.state.items.push_back(std::move(potion));
+
+    PickupSystem system;
+    system.process(t.state);
+
+    assert(t.player->stats.hp == t.player->stats.max_hp);
+    assert(t.state.items.empty());
+}
+
+void test_pickup_on_max_hp()
+{
+    auto t = make_state();
+
+    t.player->stats.hp     = 10;
+    t.player->stats.max_hp = 10;
+
+    auto potion          = std::make_unique<HealthPotion>();
+    potion->pos          = {1, 1};
+    potion->healingValue = 5;
+    t.state.items.push_back(std::move(potion));
+
+    PickupSystem system;
+    system.process(t.state);
+
+    assert(t.player->stats.hp == t.player->stats.max_hp);
+    assert(t.state.items.empty());
+}
+
+void test_pickup_multiple_items()
+{
+    auto t = make_state();
+
+    t.player->stats.hp     = 5;
+    t.player->stats.max_hp = 10;
+
+    auto key = std::make_unique<Key>();
+    key->pos = {1, 1};
+    t.state.items.push_back(std::move(key));
+
+    auto potion          = std::make_unique<HealthPotion>();
+    potion->pos          = {1, 1};
+    potion->healingValue = 5;
+    t.state.items.push_back(std::move(potion));
+
+    PickupSystem system;
+    system.process(t.state);
+
+    assert(t.player->has_key);
+    assert(t.player->stats.hp > 5);
+    assert(t.state.items.empty());
+}
+
+void test_item_on_other_tile()
+{
+    auto t = make_state();
+
+    auto key = std::make_unique<Key>();
+    key->pos = {5, 5};
+
+    t.state.items.push_back(std::move(key));
+
+    PickupSystem system;
+    system.process(t.state);
+
+    assert(!t.player->has_key);
+    assert(t.state.items.size() == 1);
+}
+
+int main()
+{
+    test_pickup_key();
+    test_pickup_health_potion();
+    test_pickup_doesnt_exceed_max_hp();
+    test_pickup_on_max_hp();
+    test_pickup_multiple_items();
+    test_item_on_other_tile();
+    test_ignore_unknown_item();
+
+    return 0;
+}

--- a/tests/app/test_app_pickupsystem.cpp
+++ b/tests/app/test_app_pickupsystem.cpp
@@ -2,8 +2,10 @@
 
 #include "domain/core/GameState.hpp"
 #include "domain/entities/actors/Player.hpp"
+#include "domain/entities/items/Coin.hpp"
 #include "domain/entities/items/HealthPotion.hpp"
 #include "domain/entities/items/Key.hpp"
+#include "domain/entities/items/Sword.hpp"
 
 #include <cassert>
 #include <memory>
@@ -165,6 +167,40 @@ void test_item_on_other_tile()
     assert(t.state.items.size() == 1);
 }
 
+void test_pickup_sword()
+{
+    auto t = make_state();
+
+    t.player->stats.atk = 5;
+
+    auto sword          = std::make_unique<Sword>();
+    sword->pos          = {1, 1};
+    sword->attack_bonus = 5;
+    t.state.items.push_back(std::move(sword));
+
+    PickupSystem system;
+    system.process(t.state);
+
+    assert(t.player->stats.atk == 10);
+    assert(t.state.items.empty());
+}
+
+void test_pickup_coin()
+{
+    auto t = make_state();
+
+    auto coin   = std::make_unique<Coin>();
+    coin->pos   = {1, 1};
+    coin->value = 1;
+    t.state.items.push_back(std::move(coin));
+
+    PickupSystem system;
+    system.process(t.state);
+
+    assert(t.state.items.empty());
+    assert(t.state.score == 1);
+}
+
 int main()
 {
     test_pickup_key();
@@ -174,6 +210,8 @@ int main()
     test_pickup_multiple_items();
     test_item_on_other_tile();
     test_ignore_unknown_item();
+    test_pickup_sword();
+    test_pickup_coin();
 
     return 0;
 }


### PR DESCRIPTION
## Description
Implemented the Pickup System and moved item pickup logic out of PlayerSystem into a dedicated PickupSystem. Added comprehensive tests covering key pickup, health potions, multiple items on the same tile, max HP handling, unknown item types, and item removal.
Extended the item system by introducing Sword and Coin items. Swords increase the player's attack, while coins increase the player's score. Updated the spawn policy and console renderer to support the new items in both ASCII and Unicode symbol sets.
Improved the in-game HUD to display the player's current HP, attack, and score, making gameplay information more accessible during play.

## Task ID in project
#20

## Checklist
- [x] I went to the project and linked this PR to the task.
- [x] I set assignee and reporter on the task.
- [x] I went to the team chat and asked for review.
