### PR TITLE
Implement combat damage rule

### DIFF
--- a/src/app/systems/CombatSystem.cpp
+++ b/src/app/systems/CombatSystem.cpp
@@ -4,6 +4,7 @@
 #include "domain/entities/actors/Actor.hpp"
 #include "domain/entities/actors/Enemy.hpp"
 #include "domain/entities/actors/Player.hpp"
+#include "domain/services/DamageCalculator.hpp"
 #include <algorithm>
 
 namespace Application::Systems {
@@ -16,12 +17,11 @@ void CombatSystem::resolve(Domain::Core::GameState &state)
         if (!attacker || !target)
             continue;
 
-        const int damage = std::max(1, intent.damage);
-        target->stats.hp -= damage;
+        const int damage =
+            Domain::Services::DamageCalculator::compute(attacker->stats, target->stats);
+        target->stats.hp = std::max(0, target->stats.hp - damage);
 
-        if (target->stats.hp <= 0) {
-            target->stats.hp = 0;
-
+        if (target->stats.hp == 0) {
             if (dynamic_cast<Domain::Entities::Player *>(target)) {
                 state.defeat = true;
             }

--- a/src/domain/services/DamageCalculator.cpp
+++ b/src/domain/services/DamageCalculator.cpp
@@ -1,10 +1,12 @@
 #include "domain/services/DamageCalculator.hpp"
 #include "domain/core/Stats.hpp"
 
+#include <algorithm>
+
 namespace Domain::Services {
-int DamageCalculator::compute(const Domain::Core::Stats &, const Domain::Core::Stats &)
+int DamageCalculator::compute(const Domain::Core::Stats &attacker,
+                              const Domain::Core::Stats &defender)
 {
-    // TODO: calculate damage based on actors stats
-    return 0;
+    return std::max(1, attacker.atk - defender.def);
 }
 } // namespace Domain::Services

--- a/tests/app/test_app_combatsystem.cpp
+++ b/tests/app/test_app_combatsystem.cpp
@@ -1,4 +1,3 @@
-#include <cassert>
 #include <memory>
 
 #include "app/systems/CombatSystem.hpp"
@@ -7,61 +6,126 @@
 
 #include "domain/entities/actors/Enemy.hpp"
 #include "domain/entities/actors/Player.hpp"
+#include "test_utils.hpp"
 
 int main()
 {
     using namespace Domain::Core;
     using namespace Domain::Entities;
     using namespace Application::Systems;
+    using TestUtils::expect;
 
-    GameState state;
+    TestUtils::reset_fail_count();
 
-    auto player      = std::make_unique<Player>();
-    player->id       = EntityId{1};
-    player->stats.hp = 10;
+    {
+        GameState state;
 
-    auto enemy      = std::make_unique<Enemy>();
-    enemy->id       = EntityId{2};
-    enemy->stats.hp = 5;
+        auto player       = std::make_unique<Player>();
+        player->id        = EntityId{1};
+        player->stats.atk = 7;
 
-    auto player_id = player->id;
-    auto enemy_id  = enemy->id;
+        auto enemy       = std::make_unique<Enemy>();
+        enemy->id        = EntityId{2};
+        enemy->stats.hp  = 10;
+        enemy->stats.def = 2;
 
-    state.actors.push_back(std::move(player));
-    state.actors.push_back(std::move(enemy));
+        const auto player_id = player->id;
+        const auto enemy_id  = enemy->id;
 
-    state.intents.push_back({player_id, enemy_id, 3});
+        state.actors.push_back(std::move(player));
+        state.actors.push_back(std::move(enemy));
+        state.intents.push_back({player_id, enemy_id, 99});
 
-    CombatSystem::resolve(state);
+        CombatSystem::resolve(state);
 
-    auto *e = state.find_actor(enemy_id);
-    assert(e != nullptr);
-    assert(e->stats.hp == 2);
+        auto *enemy_after = state.find_actor(enemy_id);
+        expect(enemy_after != nullptr, "Enemy survives normal damage");
+        if (enemy_after != nullptr) {
+            expect(enemy_after->stats.hp == 5, "Player attack uses attacker and defender stats");
+        }
+        expect(state.intents.empty(), "Resolved attack intents are cleared");
+    }
 
-    GameState state2;
+    {
+        GameState state;
 
-    auto player2      = std::make_unique<Player>();
-    player2->id       = EntityId{1};
-    player2->stats.hp = 3;
+        auto player       = std::make_unique<Player>();
+        player->id        = EntityId{1};
+        player->stats.hp  = 5;
+        player->stats.def = 10;
 
-    auto enemy2      = std::make_unique<Enemy>();
-    enemy2->id       = EntityId{2};
-    enemy2->stats.hp = 10;
+        auto enemy       = std::make_unique<Enemy>();
+        enemy->id        = EntityId{2};
+        enemy->stats.atk = 3;
 
-    auto player2_id = player2->id;
-    auto enemy2_id  = enemy2->id;
+        const auto player_id = player->id;
+        const auto enemy_id  = enemy->id;
 
-    state2.actors.push_back(std::move(player2));
-    state2.actors.push_back(std::move(enemy2));
+        state.actors.push_back(std::move(player));
+        state.actors.push_back(std::move(enemy));
+        state.intents.push_back({enemy_id, player_id, 0});
 
-    state2.intents.push_back({enemy2_id, player2_id, 3});
+        CombatSystem::resolve(state);
 
-    CombatSystem::resolve(state2);
+        auto *player_after = state.find_actor(player_id);
+        expect(player_after != nullptr, "Player remains after nonlethal damage");
+        if (player_after != nullptr) {
+            expect(player_after->stats.hp == 4, "Enemy attack deals minimum damage");
+        }
+        expect(!state.defeat, "Nonlethal damage does not cause defeat");
+    }
 
-    auto *p = state2.find_actor(player2_id);
-    assert(p != nullptr);
-    assert(p->stats.hp == 0);
-    assert(state2.defeat == true);
+    {
+        GameState state;
 
-    return 0;
+        auto player       = std::make_unique<Player>();
+        player->id        = EntityId{1};
+        player->stats.hp  = 3;
+        player->stats.def = 1;
+
+        auto enemy       = std::make_unique<Enemy>();
+        enemy->id        = EntityId{2};
+        enemy->stats.atk = 20;
+
+        const auto player_id = player->id;
+        const auto enemy_id  = enemy->id;
+
+        state.actors.push_back(std::move(player));
+        state.actors.push_back(std::move(enemy));
+        state.intents.push_back({enemy_id, player_id, 1});
+
+        CombatSystem::resolve(state);
+
+        auto *player_after = state.find_actor(player_id);
+        expect(player_after != nullptr, "Player remains in state after defeat");
+        if (player_after != nullptr) {
+            expect(player_after->stats.hp == 0, "Lethal damage clamps HP to zero");
+        }
+        expect(state.defeat, "Lethal player damage causes defeat");
+    }
+
+    {
+        GameState state;
+
+        auto player       = std::make_unique<Player>();
+        player->id        = EntityId{1};
+        player->stats.atk = 3;
+
+        auto enemy      = std::make_unique<Enemy>();
+        enemy->id       = EntityId{2};
+        enemy->stats.hp = 2;
+
+        const auto player_id = player->id;
+        const auto enemy_id  = enemy->id;
+
+        state.actors.push_back(std::move(player));
+        state.actors.push_back(std::move(enemy));
+        state.intents.push_back({player_id, enemy_id, 0});
+
+        CombatSystem::resolve(state);
+
+        expect(state.find_actor(enemy_id) == nullptr, "Dead enemy is removed");
+    }
+
+    return TestUtils::fail_count == 0 ? 0 : 1;
 }

--- a/tests/domain/test_domain_damage.cpp
+++ b/tests/domain/test_domain_damage.cpp
@@ -1,17 +1,32 @@
-#include <cstdlib>
-#include <iostream>
-
 #include "domain/core/Stats.hpp"
 #include "domain/services/DamageCalculator.hpp"
+#include "test_utils.hpp"
 
 int main()
 {
-    Domain::Core::Stats a{10, 10, 3, 1};
-    Domain::Core::Stats d{10, 10, 2, 2};
-    const int dmg = Domain::Services::DamageCalculator::compute(a, d);
-    std::cout << "[Damage] compute=" << dmg << "\n";
+    using Domain::Core::Stats;
+    using Domain::Services::DamageCalculator;
+    using TestUtils::expect;
 
-    // TODO: proper check
+    TestUtils::reset_fail_count();
 
-    return EXIT_SUCCESS;
+    Stats normal_attacker{};
+    normal_attacker.atk = 7;
+
+    Stats normal_defender{};
+    normal_defender.def = 2;
+    expect(DamageCalculator::compute(normal_attacker, normal_defender) == 5,
+           "Damage subtracts defender defense");
+
+    Stats strong_defender{};
+    strong_defender.def = 20;
+    expect(DamageCalculator::compute(normal_attacker, strong_defender) == 1,
+           "High defense keeps minimum damage");
+
+    Stats equal_defender{};
+    equal_defender.def = 7;
+    expect(DamageCalculator::compute(normal_attacker, equal_defender) == 1,
+           "Equal attack and defense deal one damage");
+
+    return TestUtils::fail_count == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Description

Implement one stats-based damage rule for every resolved attack.

- `DamageCalculator` returns `max(1, attacker.atk - defender.def)`.
- `CombatSystem` uses the calculator for player and enemy attacks.
- Lethal damage clamps HP to `0`.
- Focused tests cover normal damage, high defense, minimum damage, and lethal damage.

## Why

`DamageCalculator` returned `0`, while `CombatSystem` used `AttackIntent::damage`. Defender defense did not affect resolved combat damage.

## Impact

Player and enemy damage now uses attacker ATK and defender DEF. `AttackIntent` and other public interfaces are unchanged.

## Task ID in project

Fixes #8

## Validation

- [x] `cmake --preset debug`
- [x] `cmake --build --preset debug`
- [x] `ctest --preset debug --output-on-failure` — 21/21 passed with ASan/UBSan.
- [x] Changed test targets built and passed in Release mode.

## Checklist

- [x] I went to the project and linked this PR to the task.
- [x] I set assignee and reporter on the task.
- [x] I went to the team chat and asked for review.