### PR TITLE
Save and load feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build/
 .clangd
 .editorconfig
 CMakePresets.json
+Testing/
+logs/

--- a/src/infra/persistence_file/FileSaveGameRepo.cpp
+++ b/src/infra/persistence_file/FileSaveGameRepo.cpp
@@ -1,14 +1,338 @@
 #include "infra/persistence_file/FileSaveGameRepo.hpp"
-namespace Infrastructure::PersistenceFile {
-bool FileSaveGameRepo::save(const Domain::Core::GameState &, const std::string &)
+#include "domain/core/GameState.hpp"
+#include "domain/entities/actors/Enemy.hpp"
+#include "domain/entities/actors/Player.hpp"
+#include "domain/entities/items/Coin.hpp"
+#include "domain/entities/items/HealthPotion.hpp"
+#include "domain/entities/items/Key.hpp"
+#include "domain/entities/items/Sword.hpp"
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <limits>
+
+namespace {
+
+constexpr std::string_view PLAYER_TAG        = "PLAYER";
+constexpr std::string_view ENEMY_TAG         = "ENEMY";
+constexpr std::string_view COIN_TAG          = "COIN";
+constexpr std::string_view SWORD_TAG         = "SWORD";
+constexpr std::string_view HEALTH_POTION_TAG = "HEALTH_POTION";
+constexpr std::string_view KEY_TAG           = "KEY";
+
+bool save_rules(std::ostream &out, const Domain::Rules::GameRules &rules)
 {
-    // TODO: save game state to file
-    return false;
+    out << rules.map_w << '\n';
+    out << rules.map_h << '\n';
+    out << rules.max_rooms << '\n';
+    out << rules.room_min_size << '\n';
+    out << rules.room_max_size << '\n';
+    out << rules.enemy_count << '\n';
+    out << rules.potion_heal_max << '\n';
+    out << rules.drop_rates_note << '\n';
+
+    return true;
+}
+bool load_rules(std::istream &in, Domain::Rules::GameRules &rules)
+{
+    if (!(in >> rules.map_w))
+        return false;
+    if (!(in >> rules.map_h))
+        return false;
+    if (!(in >> rules.max_rooms))
+        return false;
+    if (!(in >> rules.room_min_size))
+        return false;
+    if (!(in >> rules.room_max_size))
+        return false;
+    if (!(in >> rules.enemy_count))
+        return false;
+    if (!(in >> rules.potion_heal_max))
+        return false;
+
+    in.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    std::getline(in, rules.drop_rates_note);
+
+    return true;
 }
 
-bool FileSaveGameRepo::load(Domain::Core::GameState &, const std::string &)
+bool save_map(std::ostream &out, const Domain::Entities::Map &map)
 {
-    // TODO: load game state from file
-    return false;
+    out << map.height() << ' ' << map.width() << '\n';
+
+    for (size_t y = 0; y < map.height(); y++) {
+        for (size_t x = 0; x < map.width(); x++) {
+            const auto &tile = map.grid().at(x, y);
+
+            out << static_cast<int>(tile.type) << ' ' << tile.blocks_movement << ' '
+                << tile.blocks_sight << '\n';
+        }
+    }
+    return true;
+}
+bool load_map(std::istream &in, Domain::Entities::Map &map)
+{
+    std::uint16_t width;
+    std::uint16_t height;
+
+    if (!(in >> height >> width))
+        return false;
+
+    map = Domain::Entities::Map{width, height};
+
+    for (size_t y = 0; y < map.height(); y++) {
+        for (size_t x = 0; x < map.width(); x++) {
+            int type;
+            bool blocks_movement;
+            bool blocks_sight;
+
+            if (!(in >> type >> blocks_movement >> blocks_sight))
+                return false;
+
+            auto &tile = map.grid().at(x, y);
+
+            tile.type            = static_cast<Domain::Entities::TileType>(type);
+            tile.blocks_movement = blocks_movement;
+            tile.blocks_sight    = blocks_sight;
+        }
+    }
+    return true;
+}
+
+bool save_actors(std::ostream &out,
+                 const std::vector<std::unique_ptr<Domain::Entities::Actor>> &actors)
+{
+    out << actors.size() << '\n';
+    for (const auto &actor : actors) {
+
+        if (auto *player = dynamic_cast<Domain::Entities::Player *>(actor.get())) {
+            out << PLAYER_TAG << '\n';
+            out << player->has_key << '\n';
+        } else if (auto *enemy = dynamic_cast<Domain::Entities::Enemy *>(actor.get())) {
+            out << ENEMY_TAG << '\n';
+            out << static_cast<int>(enemy->state) << '\n';
+        } else {
+            return false;
+        }
+
+        out << actor->id.value << '\n';
+        out << actor->pos.x << ' ' << actor->pos.y << '\n';
+        out << actor->stats.hp << ' ' << actor->stats.max_hp << ' ' << actor->stats.atk << ' '
+            << actor->stats.def << '\n';
+        out << static_cast<int>(actor->glyph.ch) << '\n';
+    }
+
+    return true;
+}
+bool load_actors(std::istream &in, std::vector<std::unique_ptr<Domain::Entities::Actor>> &actors)
+{
+    actors.clear();
+
+    std::size_t actor_count;
+    std::string type;
+
+    if (!(in >> actor_count))
+        return false;
+
+    for (std::size_t i = 0; i < actor_count; i++) {
+        if (!(in >> type))
+            return false;
+
+        std::unique_ptr<Domain::Entities::Actor> actor;
+
+        if (type == PLAYER_TAG) {
+            actor        = std::make_unique<Domain::Entities::Player>();
+            auto *player = static_cast<Domain::Entities::Player *>(actor.get());
+            if (!(in >> player->has_key))
+                return false;
+        } else if (type == ENEMY_TAG) {
+            actor       = std::make_unique<Domain::Entities::Enemy>();
+            auto *enemy = static_cast<Domain::Entities::Enemy *>(actor.get());
+            int state;
+            if (!(in >> state))
+                return false;
+            enemy->state = static_cast<Domain::Entities::EnemyState>(state);
+        } else {
+            return false;
+        }
+
+        if (!(in >> actor->id.value))
+            return false;
+
+        if (!(in >> actor->pos.x >> actor->pos.y))
+            return false;
+
+        if (!(in >> actor->stats.hp >> actor->stats.max_hp >> actor->stats.atk >> actor->stats.def))
+            return false;
+
+        int glyph_code;
+        if (!(in >> glyph_code))
+            return false;
+        actor->glyph.ch = static_cast<char>(glyph_code);
+
+        actors.push_back(std::move(actor));
+    }
+    return true;
+}
+
+bool save_items(std::ostream &out,
+                const std::vector<std::unique_ptr<Domain::Entities::Item>> &items)
+{
+    out << items.size() << '\n';
+    for (const auto &item : items) {
+        if (auto *coin = dynamic_cast<Domain::Entities::Coin *>(item.get())) {
+            out << COIN_TAG << '\n';
+            out << coin->value << '\n';
+        } else if (auto *sword = dynamic_cast<Domain::Entities::Sword *>(item.get())) {
+            out << SWORD_TAG << '\n';
+            out << sword->attack_bonus << '\n';
+        } else if (auto *healthpotion =
+                       dynamic_cast<Domain::Entities::HealthPotion *>(item.get())) {
+            out << HEALTH_POTION_TAG << '\n';
+            out << healthpotion->healingValue << '\n';
+        } else if (dynamic_cast<Domain::Entities::Key *>(item.get())) {
+            out << KEY_TAG << '\n';
+        } else {
+            return false;
+        }
+
+        out << item->id.value << '\n';
+        out << item->pos.x << ' ' << item->pos.y << '\n';
+        out << static_cast<int>(item->glyph.ch) << '\n';
+    }
+    return true;
+}
+bool load_items(std::istream &in, std::vector<std::unique_ptr<Domain::Entities::Item>> &items)
+{
+    items.clear();
+
+    std::size_t items_count;
+    std::string type;
+
+    if (!(in >> items_count))
+        return false;
+
+    for (std::size_t i = 0; i < items_count; i++) {
+        if (!(in >> type))
+            return false;
+
+        std::unique_ptr<Domain::Entities::Item> item;
+        if (type == COIN_TAG) {
+            item       = std::make_unique<Domain::Entities::Coin>();
+            auto *coin = static_cast<Domain::Entities::Coin *>(item.get());
+            if (!(in >> coin->value))
+                return false;
+
+        } else if (type == SWORD_TAG) {
+            item        = std::make_unique<Domain::Entities::Sword>();
+            auto *sword = static_cast<Domain::Entities::Sword *>(item.get());
+            if (!(in >> sword->attack_bonus))
+                return false;
+
+        } else if (type == HEALTH_POTION_TAG) {
+            item                = std::make_unique<Domain::Entities::HealthPotion>();
+            auto *health_potion = static_cast<Domain::Entities::HealthPotion *>(item.get());
+            if (!(in >> health_potion->healingValue))
+                return false;
+
+        } else if (type == KEY_TAG) {
+            item = std::make_unique<Domain::Entities::Key>();
+        } else {
+            return false;
+        }
+
+        if (!(in >> item->id.value))
+            return false;
+        if (!(in >> item->pos.x >> item->pos.y))
+            return false;
+
+        int glyph_code;
+        if (!(in >> glyph_code))
+            return false;
+        item->glyph.ch = static_cast<char>(glyph_code);
+
+        items.push_back(std::move(item));
+    }
+    return true;
+}
+} // namespace
+
+namespace Infrastructure::PersistenceFile {
+bool FileSaveGameRepo::save(const Domain::Core::GameState &state, const std::string &path)
+{
+    std::string tmp_path = path + ".tmp";
+    std::ofstream out(tmp_path);
+
+    if (!out)
+        return false;
+
+    if (!save_rules(out, state.rules))
+        return false;
+    if (!save_map(out, state.map))
+        return false;
+    if (!save_actors(out, state.actors))
+        return false;
+    if (!save_items(out, state.items))
+        return false;
+
+    out << state.defeat << '\n';
+    out << state.victory << '\n';
+    out << state.score << '\n';
+    out << state.turn << '\n';
+    out << state.quit << '\n';
+
+    if (!out.good())
+        return false;
+
+    out.close();
+
+    std::filesystem::remove(path);
+    std::filesystem::rename(tmp_path, path);
+
+    return true;
+}
+
+bool FileSaveGameRepo::load(Domain::Core::GameState &state, const std::string &path)
+{
+    std::ifstream in(path);
+    if (!in)
+        return false;
+
+    Domain::Core::GameState loaded;
+
+    if (!load_rules(in, loaded.rules)) {
+        std::cout << "load_rules failed\n";
+        return false;
+    }
+
+    if (!load_map(in, loaded.map)) {
+        std::cout << "load_map failed\n";
+        return false;
+    }
+
+    if (!load_actors(in, loaded.actors)) {
+        std::cout << "load_actors failed\n";
+        return false;
+    }
+    if (!load_items(in, loaded.items)) {
+        std::cout << "load_items failed\n";
+        return false;
+    }
+
+    if (!(in >> loaded.defeat))
+        return false;
+    if (!(in >> loaded.victory))
+        return false;
+    if (!(in >> loaded.score))
+        return false;
+    if (!(in >> loaded.turn))
+        return false;
+    if (!(in >> loaded.quit))
+        return false;
+
+    state = std::move(loaded);
+
+    return true;
 }
 } // namespace Infrastructure::PersistenceFile

--- a/src/infra/persistence_file/FileSaveGameRepo.hpp
+++ b/src/infra/persistence_file/FileSaveGameRepo.hpp
@@ -4,7 +4,7 @@
 namespace Infrastructure::PersistenceFile {
 class FileSaveGameRepo final : public Application::Persistence::ISaveGameRepo {
 public:
-    bool save(const Domain::Core::GameState &, const std::string &path) override;
-    bool load(Domain::Core::GameState &, const std::string &path) override;
+    bool save(const Domain::Core::GameState &state, const std::string &path) override;
+    bool load(Domain::Core::GameState &state, const std::string &path) override;
 };
 } // namespace Infrastructure::PersistenceFile

--- a/tests/includes/test_utils.hpp
+++ b/tests/includes/test_utils.hpp
@@ -1,7 +1,7 @@
 #pragma once
+#include "domain/entities/Map.hpp"
 #include <iostream>
 #include <string>
-#include "domain/entities/Map.hpp"
 
 namespace TestUtils {
 
@@ -21,7 +21,7 @@ inline bool expect(const bool condition, const std::string &name)
 
 inline void reset_fail_count() { fail_count = 0; }
 
-void reset_map(Domain::Entities::Map &map)
+inline void reset_map(Domain::Entities::Map &map)
 {
     for (std::size_t x = 0; x < map.width(); ++x) {
         for (std::size_t y = 0; y < map.height(); ++y) {

--- a/tests/infra/test_infra_file_repo.cpp
+++ b/tests/infra/test_infra_file_repo.cpp
@@ -1,16 +1,86 @@
 #include "domain/core/GameState.hpp"
+#include "domain/entities/Map.hpp"
+#include "domain/entities/actors/Enemy.hpp"
+#include "domain/entities/actors/Player.hpp"
+#include "domain/entities/items/Coin.hpp"
+#include "domain/rules/GameRules.hpp"
 #include "infra/persistence_file/FileSaveGameRepo.hpp"
-#include <cassert>
+#include "test_utils.hpp"
 #include <cstdlib>
 
 int main()
 {
-    Infrastructure::PersistenceFile::FileSaveGameRepo repo{};
-    Domain::Core::GameState state{};
-    assert(repo.save(state, "tmp.sav") == false);
-    assert(repo.load(state, "tmp.sav") == false);
+    using namespace Infrastructure::PersistenceFile;
+    using namespace Domain::Core;
+    using namespace Domain::Entities;
+    using TestUtils::expect;
 
-    // TODO: proper check
+    TestUtils::reset_fail_count();
+    {
+        GameState state{};
+        state.map = Map{3, 3};
+        TestUtils::reset_map(state.map);
 
-    return EXIT_SUCCESS;
+        state.score   = 100;
+        state.turn    = 12;
+        state.victory = false;
+        state.defeat  = false;
+        state.quit    = false;
+
+        state.rules.map_h       = 3;
+        state.rules.map_w       = 3;
+        state.rules.enemy_count = 1;
+
+        auto player          = std::make_unique<Player>();
+        player->id           = EntityId{1};
+        player->pos          = {1, 1};
+        player->has_key      = true;
+        player->stats.hp     = 10;
+        player->stats.max_hp = 20;
+        player->stats.atk    = 5;
+        player->stats.def    = 3;
+        player->glyph.ch     = '@';
+        state.actors.push_back(std::move(player));
+
+        auto enemy          = std::make_unique<Enemy>();
+        enemy->id           = EntityId{2};
+        enemy->pos          = {0, 0};
+        enemy->state        = EnemyState::Chasing;
+        enemy->stats.atk    = 5;
+        enemy->stats.def    = 3;
+        enemy->stats.hp     = 5;
+        enemy->stats.max_hp = 10;
+        enemy->glyph.ch     = 'E';
+        state.actors.push_back(std::move(enemy));
+
+        auto coin      = std::make_unique<Coin>();
+        coin->id       = EntityId{3};
+        coin->pos      = {2, 2};
+        coin->value    = 10;
+        coin->glyph.ch = '$';
+        state.items.push_back(std::move(coin));
+
+        FileSaveGameRepo repo{};
+        GameState restored{};
+
+        const bool saved = repo.save(state, "test_save.txt");
+        expect(saved, "Save Succeeds");
+
+        const bool loaded = repo.load(restored, "test_save.txt");
+        expect(loaded, "Load Succeeds");
+
+        if (loaded) {
+            expect(restored.rules.map_h == state.rules.map_h, "Map height restored");
+            expect(restored.rules.map_w == state.rules.map_w, "Map width restored");
+            expect(restored.rules.enemy_count == state.rules.enemy_count,
+                   "Map enemy count restored");
+
+            expect(restored.turn == state.turn, "Turn restored");
+            expect(restored.score == state.score, "Score restored");
+            expect(restored.victory == state.victory, "victory status restored");
+            expect(restored.defeat == state.defeat, "defeat status restored");
+            expect(restored.quit == state.quit, "Quit status restored");
+        }
+    }
+    return TestUtils::fail_count == 0 ? 0 : 1;
 }


### PR DESCRIPTION
## Description
Implemented 'FileSaveGameRepo' to support saving and loading the game state from a text file. The implementation stores game rules, map, actors, items, turn, score, and game flags, writes saves atomically using a temporary file, restores valid save files correctly, and includes tests to verify save/load behavior.

## Task ID in project
#29 

## Checklist
- [x] I went to the project and linked this PR to the task.
- [x] I set assignee and reporter on the task.
- [x] I went to the team chat and asked for review.
